### PR TITLE
Save AP interface when tethering is notified on.

### DIFF
--- a/src/tetheringplugin.c
+++ b/src/tetheringplugin.c
@@ -288,6 +288,7 @@ tethering_check_ap(
             all_valid = FALSE;
         } else if (i->caps.modes & GSUPPLICANT_INTERFACE_CAPS_MODES_AP) {
             ap_ifname = i->ifname;
+            connman_tethering_set_tethering_interface(ap_ifname);
         }
     }
 


### PR DESCRIPTION
Call tethering.c interface setter when an AP interface is retrieved from wpa_supplicant. This saves the interface at runtime for tethering.c that can be used by the other plugins. This works because tethering notify is done before the call to .set_tethering, where this interface is then used.